### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to pgdrift will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-06-07
+
+### Security
+
+- **Patched 5 vulnerabilities** flagged by `cargo audit`:
+  - `bytes` 1.11.0 → 1.11.1 — integer overflow / memory corruption in `BytesMut::reserve` (RUSTSEC-2026-0007)
+  - `rustls-webpki` 0.103.8 → 0.103.13 — TLS CRL matching bug (RUSTSEC-2026-0049) and URI name constraint bypass (RUSTSEC-2026-0098)
+  - `time` 0.3.44 → 0.3.47 — denial of service via stack exhaustion (RUSTSEC-2026-0009)
+  - `astral-tokio-tar` 0.5.6 → 0.6.2 — insufficient PAX extension validation (RUSTSEC-2026-0066)
+  - `rand` 0.9.2 → 0.9.4 — unsound with custom logger (RUSTSEC-2026-0097)
+
+### Dependencies
+
+- `testcontainers` 0.26 → 0.27
+- `clap` 4.5.56 → 4.5.60
+- `anyhow` 1.0.100 → 1.0.102
+- `indicatif` 0.18.3 → 0.18.4
+- `softprops/action-gh-release` CI action v2 → v3
+
+---
+
 ## [0.1.1] - 2026-02-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -73,14 +73,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "astral-tokio-tar"
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
@@ -420,7 +420,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -655,7 +655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1299,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
@@ -1651,7 +1651,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pgdrift"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "pgdrift-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "pgdrift-db",
  "serde",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "pgdrift-db"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "futures",
  "indicatif",
@@ -2065,7 +2065,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/capybarastack/pgdrift"
@@ -19,8 +19,8 @@ categories = ["command-line-utilities", "database"]
 
 [workspace.dependencies]
 # Internal crates
-pgdrift-core = { version = "0.1.1", path = "crates/pgdrift-core" }
-pgdrift-db = { version = "0.1.1", path = "crates/pgdrift-db" }
+pgdrift-core = { version = "0.1.2", path = "crates/pgdrift-core" }
+pgdrift-db = { version = "0.1.2", path = "crates/pgdrift-db" }
 
 # Database
 sqlx = { version = "0.8", features = ["postgres", "runtime-tokio", "json", "tls-rustls"] }


### PR DESCRIPTION
## v0.1.2 Release PR

Bumps version to `0.1.2` and includes the remaining dependency updates alongside the security fixes already merged in #14.

### Changes

**Version:** `0.1.1` → `0.1.2` in `Cargo.toml` and `Cargo.lock`

**Remaining dependency bumps (from open Dependabot PRs):**
- `clap` 4.5.56 → 4.5.60
- `anyhow` 1.0.100 → 1.0.102
- `indicatif` 0.18.3 → 0.18.4

**Changelog:** `CHANGELOG.md` updated with full v0.1.2 entry

Once this merges, the release is cut by pushing tag `v0.1.2` to main, which triggers the release workflow to build binaries and publish to crates.io.

https://claude.ai/code/session_01Q7r36BSeTFoeKdXV5UKa9s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7r36BSeTFoeKdXV5UKa9s)_